### PR TITLE
Fix StudioPanel lookup when inactive

### DIFF
--- a/Assets/Scripts/Controller/StudioController.cs
+++ b/Assets/Scripts/Controller/StudioController.cs
@@ -88,24 +88,24 @@ public class StudioController : MonoBehaviour
 
     private void InitUI()
     {
-        GameObject canvas = GameObject.Find("Canvas");
-        if (canvas == null)
+        GameObject canvasGO = GameObject.Find("Canvas");
+        if (canvasGO == null)
         {
-            Debug.LogError("StudioController.InitUI: Canvas not found");
+            Debug.LogError("StudioController: 'Canvas' not found.");
             return;
         }
 
-        Transform panelTransform = canvas.transform.Find("StudioPanel");
-        if (panelTransform == null)
+        GameObject panelGO = canvasGO.transform.Find("StudioPanel")?.gameObject;
+        if (panelGO == null)
         {
-            Debug.LogError("StudioController.InitUI: StudioPanel not found");
+            Debug.LogError("StudioController: 'StudioPanel' not found (even if inactive).");
             return;
         }
 
-        studioPanel = panelTransform.GetComponent<StudioPanel>();
+        studioPanel = panelGO.GetComponent<StudioPanel>();
         if (studioPanel == null)
         {
-            Debug.LogError("StudioController.InitUI: StudioPanel component missing");
+            Debug.LogError("StudioController: StudioPanel component missing.");
             return;
         }
         studioPanel.Init();

--- a/Assets/Scripts/Controller/StudioController.cs
+++ b/Assets/Scripts/Controller/StudioController.cs
@@ -88,7 +88,26 @@ public class StudioController : MonoBehaviour
 
     private void InitUI()
     {
-        studioPanel = GameObject.Find("/Canvas/StudioPanel").GetComponent<StudioPanel>();
+        GameObject canvas = GameObject.Find("Canvas");
+        if (canvas == null)
+        {
+            Debug.LogError("StudioController.InitUI: Canvas not found");
+            return;
+        }
+
+        Transform panelTransform = canvas.transform.Find("StudioPanel");
+        if (panelTransform == null)
+        {
+            Debug.LogError("StudioController.InitUI: StudioPanel not found");
+            return;
+        }
+
+        studioPanel = panelTransform.GetComponent<StudioPanel>();
+        if (studioPanel == null)
+        {
+            Debug.LogError("StudioController.InitUI: StudioPanel component missing");
+            return;
+        }
         studioPanel.Init();
         studioPanel.OnItemBeginDrag = HandleUIItemBeginDrag;
         studioPanel.OnBuildClick = PlaceWall;


### PR DESCRIPTION
## Summary
- locate the Canvas directly and search for `StudioPanel` under it
- log errors when Canvas or StudioPanel cannot be found
- avoid `NullReferenceException` if `StudioPanel` is disabled at load

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886914b2b048322b9c9cbe2aa69c5bc