### PR TITLE
Fix House panel button crash

### DIFF
--- a/Assets/Scripts/Controller/StudioController.cs
+++ b/Assets/Scripts/Controller/StudioController.cs
@@ -36,11 +36,11 @@ public class StudioController : MonoBehaviour
     private bool isEditItemHandleDrag;
     private bool isEditItemHandleClick;
 
+    private bool initialized = false;
+
     private void Start()
     {
-        InitUI();
-        InitTouch();
-        InitView();
+        Initialize();
 
         if (initializeOnStart)
         {
@@ -48,6 +48,17 @@ public class StudioController : MonoBehaviour
             studioPanel.SetResetButtonActive(false);
             studioPanel.SetMode(StudioMode.Type);
         }
+    }
+
+    private void Initialize()
+    {
+        if (initialized) return;
+
+        InitUI();
+        InitTouch();
+        InitView();
+
+        initialized = true;
     }
 
     #region Init
@@ -77,7 +88,9 @@ public class StudioController : MonoBehaviour
 }
 
     public void OpenRoom(string prefabName)
-{
+    {
+    Initialize();
+
     if (room != null) Destroy(room.gameObject);
 
     GameObject prefab = Resources.Load<GameObject>("Prefabs/" + prefabName);


### PR DESCRIPTION
## Summary
- ensure `StudioController` initializes before calling `OpenRoom`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68869c39e82c83228aeb52e6ac544639