### PR TITLE
Add BackButton to HousePanel

### DIFF
--- a/Assets/Scenes/Start.unity
+++ b/Assets/Scenes/Start.unity
@@ -543,6 +543,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1593533691}
+  - {fileID: 2060827231}
   m_Father: {fileID: 571944022}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -2147,6 +2148,126 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1593533690}
+  m_CullTransparentMesh: 1
+--- !u!1 &2060827230
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2060827231}
+  - component: {fileID: 2060827234}
+  - component: {fileID: 2060827233}
+  - component: {fileID: 2060827232}
+  m_Layer: 5
+  m_Name: BackButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2060827231
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2060827230}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 400041958}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -60, y: -60}
+  m_SizeDelta: {x: 120, y: 60}
+  m_Pivot: {x: 1, y: 1}
+--- !u!114 &2060827232
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2060827230}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 1, g: 1, b: 1, a: 1}
+    m_PressedColor: {r: 0.8666667, g: 0.8666667, b: 0.8666667, a: 1}
+    m_SelectedColor: {r: 1, g: 1, b: 1, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2060827233}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &2060827233
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2060827230}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 74397ba99d4b746779728e0b2da9cba4, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2060827234
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2060827230}
   m_CullTransparentMesh: 1
 --- !u!1 &1600304366
 GameObject:

--- a/Assets/Scripts/Controller/HouseController.cs
+++ b/Assets/Scripts/Controller/HouseController.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 [DefaultExecutionOrder(-100)]
 public class HouseController : MonoBehaviour
@@ -59,6 +60,10 @@ public class HouseController : MonoBehaviour
         housePanel.Init();
         housePanel.Hide();                     // start hidden
         housePanel.OnRoomClick = OpenRoom;
+        housePanel.OnBackClick = () =>
+        {
+            ReturnToStart();
+        };
 
         studioPanel.SetActive(false);          // hide Studio HUD until inside a room
     }
@@ -83,5 +88,10 @@ public class HouseController : MonoBehaviour
 
         studioController?.OpenRoom(prefabName); // ← pass raw name ONLY
         housePanel.Hide();
+    }
+
+    private void ReturnToStart()
+    {
+        UnityEngine.SceneManagement.SceneManager.LoadScene("Start");
     }
 }

--- a/Assets/Scripts/UI/Panel/HousePanel.cs
+++ b/Assets/Scripts/UI/Panel/HousePanel.cs
@@ -12,8 +12,15 @@ public struct RoomEntry
 public class HousePanel : MonoBehaviour
 {
     public RoomEntry[] rooms;    // map UI buttons to prefab names
-    
+
     public Action<string> OnRoomClick;
+
+    public Action OnBackClick
+    {
+        set { backButton.onClick.AddListener(() => value()); }
+    }
+
+    private Button backButton;
 
     
     public void Init()
@@ -22,6 +29,7 @@ public class HousePanel : MonoBehaviour
         {
             new RoomEntry { buttonName = "Bedroom", prefabName = "Room" }
         };
+        backButton = transform.Find("BackButton").GetComponent<Button>();
         foreach (var entry in rooms)
         {
             Transform t = transform.Find(entry.buttonName + "Button");


### PR DESCRIPTION
## Summary
- add BackButton object in `Start.unity`
- wire up back button handling in `HousePanel`
- expose BackButton event in `HousePanel`
- hook BackButton in `HouseController` to reload Start scene

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6887b28b6c50832287783e48b6b513e2