### PR TITLE
Fix missing SaveRoomState helpers

### DIFF
--- a/Assets/Scripts/View/Direction.cs
+++ b/Assets/Scripts/View/Direction.cs
@@ -23,6 +23,12 @@ public class Direction
     public static Direction H = new Direction(7, new Vector3(-1, 0, 1));
 
     private static Direction[] directions = { A, B, C, D, E, F, G, H };
+
+    public static Direction FromValue(int value)
+    {
+        value = Mathf.Abs(value) % directions.Length;
+        return directions[value];
+    }
     public int Value;
     public Vector3 Vector;
 

--- a/Assets/Scripts/View/Room.cs
+++ b/Assets/Scripts/View/Room.cs
@@ -216,6 +216,21 @@ public class Room : MonoBehaviour
         wallMaterial.SetTexture("_DetailTex", tex);
     }
 
+    public List<ItemSaveData> GetItemStates()
+    {
+        List<ItemSaveData> states = new List<ItemSaveData>();
+        foreach (var obj in items)
+        {
+            if (obj == null) continue;
+            ItemSaveData data = new ItemSaveData();
+            data.prefab = obj.name;
+            data.position = obj.Item.Position;
+            data.direction = obj.Item.Dir.Value;
+            states.Add(data);
+        }
+        return states;
+    }
+
     private bool ItemXYZ(Item item, out int minX, out int maxX, out int minY, out int maxY, out int minZ, out int maxZ)
     {
         Vector3Int rotateSize = item.RotateSize;


### PR DESCRIPTION
## Summary
- implement `Room.GetItemStates` used by StudioController
- add `Direction.FromValue` to build directions from saved data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887bd8c90048322b7961ea574ce3e04