### PR TITLE
Add room preview capture

### DIFF
--- a/Assets/Scripts/Controller/StudioController.cs
+++ b/Assets/Scripts/Controller/StudioController.cs
@@ -24,6 +24,8 @@ public class StudioController : MonoBehaviour
     private EditedItem editedItem;
     private GridGroup gridGroup;
 
+    private string currentPrefabName;
+
     // UI
     private StudioPanel studioPanel;
 
@@ -89,7 +91,9 @@ public class StudioController : MonoBehaviour
 
     public void OpenRoom(string prefabName)
     {
-    Initialize();
+        Initialize();
+
+        currentPrefabName = prefabName;
 
     if (room != null) Destroy(room.gameObject);
 
@@ -171,10 +175,18 @@ public class StudioController : MonoBehaviour
 
         studioPanel.OnBackClick = () =>
         {
-            SaveRoomState();
-            GetComponent<HouseController>()?.ReturnToHouse();
+            StartCoroutine(BackWithPreview());
         };
 
+    }
+
+    private IEnumerator BackWithPreview()
+    {
+        SaveRoomState();
+        yield return new WaitForEndOfFrame();
+        Texture2D tex = ScreenCapture.CaptureScreenshotAsTexture();
+        RoomPreview.Set(currentPrefabName, tex);
+        GetComponent<HouseController>()?.ReturnToHouse();
     }
 
     private void InitTouch()

--- a/Assets/Scripts/Data/RoomPreview.cs
+++ b/Assets/Scripts/Data/RoomPreview.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class RoomPreview
+{
+    private static Dictionary<string, Sprite> previews = new Dictionary<string, Sprite>();
+
+    public static void Set(string roomName, Texture2D texture)
+    {
+        if (texture == null) return;
+        Sprite sprite = Sprite.Create(texture, new Rect(0, 0, texture.width, texture.height), new Vector2(0.5f, 0.5f));
+        if (previews.ContainsKey(roomName))
+            previews[roomName] = sprite;
+        else
+            previews.Add(roomName, sprite);
+    }
+
+    public static Sprite Get(string roomName)
+    {
+        Sprite sprite;
+        previews.TryGetValue(roomName, out sprite);
+        return sprite;
+    }
+}

--- a/Assets/Scripts/Data/RoomPreview.cs.meta
+++ b/Assets/Scripts/Data/RoomPreview.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0604b0ab160e4ee5b276fdd1ad7e5243
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UI/Panel/HousePanel.cs
+++ b/Assets/Scripts/UI/Panel/HousePanel.cs
@@ -42,6 +42,11 @@ public class HousePanel : MonoBehaviour
             Button btn = t.GetComponent<Button>();
             string prefab = entry.prefabName;
             btn.onClick.AddListener(() => OnRoomClick?.Invoke(prefab));
+
+            Image img = t.GetComponent<Image>();
+            Sprite preview = RoomPreview.Get(prefab);
+            if (img != null && preview != null)
+                img.sprite = preview;
         }
     }
 


### PR DESCRIPTION
## Summary
- capture a screenshot when leaving a room
- keep screenshots in `RoomPreview`
- show preview images on the house panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887c05c6be483228b581dfbc755a370