### PR TITLE
Crop preview screenshot to 512 square

### DIFF
--- a/Assets/Scripts/Controller/StudioController.cs
+++ b/Assets/Scripts/Controller/StudioController.cs
@@ -185,8 +185,23 @@ public class StudioController : MonoBehaviour
         SaveRoomState();
         yield return new WaitForEndOfFrame();
         Texture2D tex = ScreenCapture.CaptureScreenshotAsTexture();
-        RoomPreview.Set(currentPrefabName, tex);
+        Texture2D cropped = CropCenter(tex, 512, 512);
+        RoomPreview.Set(currentPrefabName, cropped);
+        Destroy(tex);
         GetComponent<HouseController>()?.ReturnToHouse();
+    }
+
+    private Texture2D CropCenter(Texture2D source, int width, int height)
+    {
+        int x = Mathf.Max(0, (source.width - width) / 2);
+        int y = Mathf.Max(0, (source.height - height) / 2);
+        int w = Mathf.Min(width, source.width);
+        int h = Mathf.Min(height, source.height);
+        Color[] pixels = source.GetPixels(x, y, w, h);
+        Texture2D result = new Texture2D(w, h);
+        result.SetPixels(pixels);
+        result.Apply();
+        return result;
     }
 
     private void InitTouch()

--- a/Assets/Scripts/UI/Panel/HousePanel.cs
+++ b/Assets/Scripts/UI/Panel/HousePanel.cs
@@ -22,6 +22,19 @@ public class HousePanel : MonoBehaviour
 
     private Button backButton;
 
+    private void UpdateRoomPreviews()
+    {
+        foreach (var entry in rooms)
+        {
+            Transform t = transform.Find(entry.buttonName + "Button");
+            if (t == null) continue;
+            Image img = t.GetComponent<Image>();
+            Sprite preview = RoomPreview.Get(entry.prefabName);
+            if (img != null && preview != null)
+                img.sprite = preview;
+        }
+    }
+
     
     public void Init()
     {
@@ -42,16 +55,13 @@ public class HousePanel : MonoBehaviour
             Button btn = t.GetComponent<Button>();
             string prefab = entry.prefabName;
             btn.onClick.AddListener(() => OnRoomClick?.Invoke(prefab));
-
-            Image img = t.GetComponent<Image>();
-            Sprite preview = RoomPreview.Get(prefab);
-            if (img != null && preview != null)
-                img.sprite = preview;
         }
+        UpdateRoomPreviews();
     }
 
     public void Show()
     {
+        UpdateRoomPreviews();
         gameObject.SetActive(true);
     }
 


### PR DESCRIPTION
## Summary
- crop screenshot to 512x512 from the screen centre when leaving the Studio
- add `CropCenter` helper
- refresh preview images each time the House panel is shown

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887c6d1edcc83228148955d9c09ce70