### PR TITLE
Fix per-room save key

### DIFF
--- a/Assets/Scripts/Controller/StudioController.cs
+++ b/Assets/Scripts/Controller/StudioController.cs
@@ -939,13 +939,13 @@ public class StudioController : MonoBehaviour
     {
         if (room == null) return;
         List<ItemSaveData> items = room.GetItemStates();
-        RoomSave.Save(items);
+        RoomSave.Save(currentPrefabName, items);
     }
 
     private void LoadRoomState()
     {
         if (room == null) return;
-        List<ItemSaveData> states = RoomSave.Load();
+        List<ItemSaveData> states = RoomSave.Load(currentPrefabName);
         foreach (var state in states)
         {
             ItemPO po = ItemData.GetByName(state.prefab);

--- a/Assets/Scripts/Data/RoomSave.cs
+++ b/Assets/Scripts/Data/RoomSave.cs
@@ -17,22 +17,29 @@ public class RoomSaveData
 
 public static class RoomSave
 {
-    private const string SaveKey = "RoomState";
+    private const string SaveKeyPrefix = "RoomState_";
 
-    public static void Save(List<ItemSaveData> items)
+    public static void Save(string roomName, List<ItemSaveData> items)
     {
+        if (string.IsNullOrEmpty(roomName)) return;
+
         RoomSaveData data = new RoomSaveData();
         data.items = items;
         string json = JsonUtility.ToJson(data);
-        PlayerPrefs.SetString(SaveKey, json);
+        PlayerPrefs.SetString(SaveKeyPrefix + roomName, json);
         PlayerPrefs.Save();
     }
 
-    public static List<ItemSaveData> Load()
+    public static List<ItemSaveData> Load(string roomName)
     {
-        if (!PlayerPrefs.HasKey(SaveKey))
+        if (string.IsNullOrEmpty(roomName))
             return new List<ItemSaveData>();
-        string json = PlayerPrefs.GetString(SaveKey);
+
+        string key = SaveKeyPrefix + roomName;
+        if (!PlayerPrefs.HasKey(key))
+            return new List<ItemSaveData>();
+
+        string json = PlayerPrefs.GetString(key);
         RoomSaveData data = JsonUtility.FromJson<RoomSaveData>(json);
         if (data == null || data.items == null) return new List<ItemSaveData>();
         return data.items;


### PR DESCRIPTION
## Summary
- make room state saving use a key per room
- load and save room state based on the current prefab name

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688908a08b9c83228809e2afaa3a447f