### PR TITLE
Show item prices in drag item cell

### DIFF
--- a/Assets/Resources/Prefabs/UI/DragItemCell.prefab
+++ b/Assets/Resources/Prefabs/UI/DragItemCell.prefab
@@ -154,6 +154,85 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: Button
+--- !u!1 &1486986459311824
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 224556789012345678}
+  - component: {fileID: 222556789012345678}
+  - component: {fileID: 114556789012345678}
+  m_Layer: 5
+  m_Name: price
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &224556789012345678
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1486986459311824}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 224778389175904986}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -2}
+  m_SizeDelta: {x: 0, y: 20}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &222556789012345678
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1486986459311824}
+  m_CullTransparentMesh: 0
+--- !u!114 &114556789012345678
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1486986459311824}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Button
 --- !u!1 &1558243603590256
 GameObject:
   m_ObjectHideFlags: 0
@@ -187,6 +266,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 224142098072651386}
+  - {fileID: 224556789012345678}
   - {fileID: 224933667220830280}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/PO/ItemPO.cs
+++ b/Assets/Scripts/PO/ItemPO.cs
@@ -9,4 +9,5 @@ public class ItemPO
     public Vector3Int size;
     public bool isOccupied;
     public Vector3 offset;
+    public int cost;
 }

--- a/Assets/Scripts/UI/DragItemCell.cs
+++ b/Assets/Scripts/UI/DragItemCell.cs
@@ -12,6 +12,7 @@ public class DragItemCell : Cell, IBeginDragHandler, IDragHandler, IEndDragHandl
 
     private bool scroll;
     private Text nameText;
+    private Text priceText;
     private Image image;
 
     void Start()
@@ -24,6 +25,7 @@ public class DragItemCell : Cell, IBeginDragHandler, IDragHandler, IEndDragHandl
     public override void Init()
     {
         nameText = transform.Find("name").GetComponent<Text>();
+        priceText = transform.Find("price").GetComponent<Text>();
         image = transform.Find("image").GetComponent<Image>();
     }
 
@@ -70,6 +72,7 @@ public class DragItemCell : Cell, IBeginDragHandler, IDragHandler, IEndDragHandl
     public void SetItem(ItemPO item)
     {
         nameText.text = item.name;
+        priceText.text = item.cost.ToString();
         string path = string.Format("Images/Items/{0}_512", item.name);
         Sprite sprite = Resources.Load<Sprite>(path) as Sprite;
         if (sprite)


### PR DESCRIPTION
## Summary
- add `priceText` to `DragItemCell` and populate it from `ItemPO.cost`
- include new `cost` field in `ItemPO`
- update `DragItemCell` prefab with new `price` UI element

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a78670c7c83229d2730edd531415c