### PR TITLE
Add introductory panel sequence and replay option

### DIFF
--- a/Assets/Resources/Prefabs/IntroPanel.prefab
+++ b/Assets/Resources/Prefabs/IntroPanel.prefab
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_Name: IntroPanel
+  m_Component:
+  - component: {fileID: 22410000}
+  - component: {fileID: 11410000}
+  m_IsActive: 1
+--- !u!224 &22410000
+RectTransform:
+  m_GameObject: {fileID: 1}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &11410000
+MonoBehaviour:
+  m_GameObject: {fileID: 1}
+  m_Script: {fileID: 0}
+  m_Name:
+  m_EditorClassIdentifier:

--- a/Assets/Resources/Prefabs/IntroPanel.prefab.meta
+++ b/Assets/Resources/Prefabs/IntroPanel.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 68f3f7485cc14ccbaa6b37920483240c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UI/IntroSequence.cs
+++ b/Assets/Scripts/UI/IntroSequence.cs
@@ -1,0 +1,129 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+[System.Serializable]
+public struct PanelData
+{
+    public Sprite background;
+    public string text;
+    public float holdTime;
+}
+
+public class IntroSequence : MonoBehaviour
+{
+    [SerializeField] PanelData[] panels;
+    [SerializeField] string panelPrefabPath = "Prefabs/IntroPanel";
+
+    int currentIndex;
+    bool hasSeenIntro = PlayerPrefs.GetInt("IntroSeen", 0) == 1;
+
+    GameObject currentPanel;
+    GameObject panelPrefab;
+
+    void Start()
+    {
+        if (hasSeenIntro)
+        {
+            gameObject.SetActive(false);
+            return;
+        }
+
+        currentIndex = -1;
+        panelPrefab = Resources.Load<GameObject>(panelPrefabPath);
+        ShowNextPanel();
+    }
+
+    void Update()
+    {
+        if (Input.GetMouseButtonDown(0) ||
+            (Input.touchCount > 0 && Input.GetTouch(0).phase == TouchPhase.Began))
+        {
+            ShowNextPanel();
+        }
+    }
+
+    public void ShowNextPanel()
+    {
+        if (hasSeenIntro)
+            return;
+
+        StopAllCoroutines();
+        StartCoroutine(Transition());
+    }
+
+    IEnumerator Transition()
+    {
+        if (currentPanel != null)
+        {
+            yield return FadeOut(currentPanel);
+            Destroy(currentPanel);
+        }
+
+        currentIndex++;
+        if (currentIndex >= panels.Length)
+        {
+            EndIntro();
+            yield break;
+        }
+
+        if (panelPrefab == null)
+            yield break;
+
+        currentPanel = Instantiate(panelPrefab, transform);
+        var cg = currentPanel.GetComponent<CanvasGroup>();
+        if (cg != null) cg.alpha = 0f;
+
+        var data = panels[currentIndex];
+        var img = currentPanel.GetComponentInChildren<Image>();
+        if (img != null) img.sprite = data.background;
+
+        var txt = currentPanel.GetComponentInChildren<TMP_Text>();
+        if (txt != null) txt.text = data.text;
+
+        var skip = currentPanel.GetComponentInChildren<Button>();
+        if (skip != null) skip.onClick.AddListener(Skip);
+
+        yield return FadeIn(currentPanel);
+        yield return new WaitForSeconds(data.holdTime);
+    }
+
+    IEnumerator FadeOut(GameObject go)
+    {
+        var cg = go.GetComponent<CanvasGroup>();
+        if (cg == null) yield break;
+        for (float t = 0f; t < 1f; t += Time.deltaTime)
+        {
+            cg.alpha = 1f - t;
+            yield return null;
+        }
+        cg.alpha = 0f;
+    }
+
+    IEnumerator FadeIn(GameObject go)
+    {
+        var cg = go.GetComponent<CanvasGroup>();
+        if (cg == null) yield break;
+        for (float t = 0f; t < 1f; t += Time.deltaTime)
+        {
+            cg.alpha = t;
+            yield return null;
+        }
+        cg.alpha = 1f;
+    }
+
+    public void Skip()
+    {
+        currentIndex = panels.Length - 1;
+        ShowNextPanel();
+    }
+
+    void EndIntro()
+    {
+        PlayerPrefs.SetInt("IntroSeen", 1);
+        PlayerPrefs.Save();
+        SendMessage("StartGuidance", SendMessageOptions.DontRequireReceiver);
+        gameObject.SetActive(false);
+    }
+}

--- a/Assets/Scripts/UI/IntroSequence.cs.meta
+++ b/Assets/Scripts/UI/IntroSequence.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e631b4af0c934d0ba47dbad09b120ae9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UI/ReplayIntro.cs
+++ b/Assets/Scripts/UI/ReplayIntro.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class ReplayIntro : MonoBehaviour
+{
+    public void Replay()
+    {
+        PlayerPrefs.SetInt("IntroSeen", 0);
+        PlayerPrefs.Save();
+        SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
+    }
+}

--- a/Assets/Scripts/UI/ReplayIntro.cs.meta
+++ b/Assets/Scripts/UI/ReplayIntro.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f237f9403188499c8a35d512ed2e01a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Create `IntroSequence` to display panel-based opening sequences and allow skipping
- Add replay button script to reset intro progress and reload the scene
- Include placeholder `IntroPanel` prefab for sequence panels

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890e01edba48322bbf303c567169209