### PR TITLE
feat: add character portraits to intro sequence

### DIFF
--- a/Assets/Resources/Prefabs/IntroPanel.prefab
+++ b/Assets/Resources/Prefabs/IntroPanel.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 1989340612681683230}
   - component: {fileID: 4820567337544638928}
   m_Layer: 0
-  m_Name: Image
+  m_Name: Background
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -32,10 +32,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 931434866283519793}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -539.9, y: -37}
-  m_SizeDelta: {x: 100, y: 100}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1989340612681683230
 CanvasRenderer:
@@ -57,6 +57,82 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+
+--- !u!1 &6800000000000000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6800000000000000001}
+  - component: {fileID: 6800000000000000002}
+  - component: {fileID: 6800000000000000003}
+  m_Layer: 0
+  m_Name: Character
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6800000000000000001
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6800000000000000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 931434866283519793}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 256, y: 256}
+  m_Pivot: {x: 0, y: 0}
+--- !u!222 &6800000000000000002
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6800000000000000000}
+  m_CullTransparentMesh: 1
+--- !u!114 &6800000000000000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6800000000000000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -108,6 +184,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7169086737556671842}
+  - {fileID: 6800000000000000001}
   - {fileID: 8774182443355150837}
   - {fileID: 5992505615500000001}
   m_Father: {fileID: 5024926086654444506}
@@ -493,7 +570,7 @@ GameObject:
   - component: {fileID: 5537806159070169518}
   - component: {fileID: 3028143208246078512}
   m_Layer: 0
-  m_Name: Text (TMP)
+  m_Name: DialogueText
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -513,11 +590,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 931434866283519793}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.00051117, y: -149.55}
-  m_SizeDelta: {x: 1179.8, y: 125.1}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0}
 --- !u!222 &5537806159070169518
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Start.unity
+++ b/Assets/Scenes/Start.unity
@@ -3839,6 +3839,85 @@ MonoBehaviour:
   m_LightCookieSize: {x: 1, y: 1}
   m_LightCookieOffset: {x: 0, y: 0}
   m_SoftShadowQuality: 0
+
+--- !u!1 &2100000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2100000001}
+  - component: {fileID: 2100000002}
+  m_Layer: 0
+  m_Name: IntroManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2100000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100000000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2100000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 594f50c59ae51f9489ea9f396a0fdd7e, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  panels:
+  - background: {fileID: 0}
+    character: {fileID: 0}
+    text: Panel 1
+    holdTime: 2
+  - background: {fileID: 0}
+    character: {fileID: 0}
+    text: Panel 2
+    holdTime: 2
+  - background: {fileID: 0}
+    character: {fileID: 0}
+    text: Panel 3
+    holdTime: 2
+  - background: {fileID: 0}
+    character: {fileID: 0}
+    text: Panel 4
+    holdTime: 2
+  - background: {fileID: 0}
+    character: {fileID: 0}
+    text: Panel 5
+    holdTime: 2
+  - background: {fileID: 0}
+    character: {fileID: 0}
+    text: Panel 6
+    holdTime: 2
+  - background: {fileID: 0}
+    character: {fileID: 0}
+    text: Panel 7
+    holdTime: 2
+  - background: {fileID: 0}
+    character: {fileID: 0}
+    text: Panel 8
+    holdTime: 2
+  panelPrefabPath: Prefabs/IntroPanel
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -3857,3 +3936,4 @@ SceneRoots:
   - {fileID: 117967099}
   - {fileID: 697538397}
   - {fileID: 1662965737}
+  - {fileID: 2100000001}

--- a/Assets/Scripts/UI/IntroSequence.cs
+++ b/Assets/Scripts/UI/IntroSequence.cs
@@ -2,11 +2,13 @@ using System.Collections;
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
+using UnityEngine.SceneManagement;
 
 [System.Serializable]
 public struct PanelData
 {
     public Sprite background;
+    public Sprite character;
     public string text;
     public float holdTime;
 }
@@ -21,12 +23,15 @@ public class IntroSequence : MonoBehaviour
 
     GameObject currentPanel;
     GameObject panelPrefab;
+    Image backgroundImage;
+    Image characterImage;
+    TMP_Text dialogueText;
 
     void Start()
     {
         if (hasSeenIntro)
         {
-            gameObject.SetActive(false);
+            SceneManager.LoadScene("DemoScene");
             return;
         }
 
@@ -78,17 +83,25 @@ public class IntroSequence : MonoBehaviour
         var cg = currentPanel.GetComponentInChildren<CanvasGroup>();
         if (cg != null) cg.alpha = 0f;
 
-        var data = panels[currentIndex];
-        var img = currentPanel.GetComponentInChildren<Image>();
-        if (img != null) img.sprite = data.background;
-
-        var txt = currentPanel.GetComponentInChildren<TMP_Text>();
-        if (txt != null) txt.text = data.text;
+        backgroundImage = currentPanel.transform.Find("Background")?.GetComponent<Image>();
+        characterImage = currentPanel.transform.Find("Character")?.GetComponent<Image>();
+        dialogueText = currentPanel.transform.Find("DialogueText")?.GetComponent<TMP_Text>();
 
         var skip = currentPanel.GetComponentInChildren<Button>();
         if (skip != null) skip.onClick.AddListener(Skip);
 
+        var data = panels[currentIndex];
+        if (backgroundImage != null) backgroundImage.sprite = data.background;
+        if (characterImage != null) characterImage.sprite = data.character;
+        if (dialogueText != null)
+        {
+            dialogueText.text = data.text;
+            dialogueText.maxVisibleCharacters = 0;
+        }
+
         yield return FadeIn(currentPanel);
+        if (dialogueText != null)
+            yield return RevealText(dialogueText);
         yield return new WaitForSeconds(data.holdTime);
     }
 
@@ -122,12 +135,22 @@ public class IntroSequence : MonoBehaviour
         ShowNextPanel();
     }
 
+    IEnumerator RevealText(TMP_Text txt)
+    {
+        txt.ForceMeshUpdate();
+        int total = txt.textInfo.characterCount;
+        for (int i = 0; i <= total; i++)
+        {
+            txt.maxVisibleCharacters = i;
+            yield return new WaitForSeconds(0.02f);
+        }
+    }
+
     void EndIntro()
     {
         PlayerPrefs.SetInt("IntroSeen", 1);
         PlayerPrefs.Save();
         hasSeenIntro = true;
-        SendMessage("StartGuidance", SendMessageOptions.DontRequireReceiver);
-        gameObject.SetActive(false);
+        SceneManager.LoadScene("DemoScene");
     }
 }

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,14 +6,11 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
-    path: Assets/Scenes/SampleScene.unity
-    guid: 99c9720ab356a0642a771bea13969a05
+    path: Assets/Scenes/Start.unity
+    guid: c7393ffd9b67c4de8a08bc9b99d4183e
   - enabled: 1
     path: Assets/SimplePoly - Town Pack/DemoScene/DemoScene.unity
     guid: d03355cb2b2cc99428f6e1bfb113b182
-  - enabled: 1
-    path: Assets/Scenes/Start.unity
-    guid: c7393ffd9b67c4de8a08bc9b99d4183e
   m_configObjects:
     com.unity.adaptiveperformance.google.android.provider_settings: {fileID: 11400000, guid: d77aa80165d4f734a90e9c8200b3e959, type: 2}
     com.unity.adaptiveperformance.loader_settings: {fileID: 11400000, guid: 093e0ed43afc1984daca2af938bfafee, type: 2}


### PR DESCRIPTION
## Summary
- support per-panel character portraits and typewriter text reveal
- layout intro panel with full-screen background, portrait image and wider text area
- load DemoScene automatically after intro or when intro previously seen

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689233768f7c8322919e1648594c0361